### PR TITLE
Changed the URL for Debian 10

### DIFF
--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,0 +1,2 @@
+fish_apt_key_url: https://download.opensuse.org/repositories/shells:/fish:/release:/{{ fish_release_version }}/Debian_{{ ansible_facts.distribution_major_version }}/Release.key
+fish_apt_repo_url: deb http://download.opensuse.org/repositories/shells:/fish:/release:/{{ fish_release_version }}/Debian_{{ ansible_facts.distribution_major_version }}/ /

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,2 +1,0 @@
-fish_apt_key_url: https://download.opensuse.org/repositories/shells:/fish:/release:/{{ fish_release_version }}/Debian_{{ ansible_facts.distribution_major_version }}/Release.key
-fish_apt_repo_url: deb http://download.opensuse.org/repositories/shells:/fish:/release:/{{ fish_release_version }}/Debian_{{ ansible_facts.distribution_major_version }}/ /

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,2 +1,2 @@
-fish_apt_key_url: https://download.opensuse.org/repositories/shells:/fish:/release:/{{ fish_release_version }}/Debian_{{ ansible_facts.distribution_major_version }}.0/Release.key
-fish_apt_repo_url: deb http://download.opensuse.org/repositories/shells:/fish:/release:/{{ fish_release_version }}/Debian_{{ ansible_facts.distribution_major_version }}.0/ /
+fish_apt_key_url: https://download.opensuse.org/repositories/shells:/fish:/release:/{{ fish_release_version }}/Debian_{{ ansible_facts.distribution_major_version }}{{ '.0' if ansible_facts.distribution_major_version is version('9', '<=') else '' }}/Release.key
+fish_apt_repo_url: deb http://download.opensuse.org/repositories/shells:/fish:/release:/{{ fish_release_version }}/Debian_{{ ansible_facts.distribution_major_version }}{{ '.0' if ansible_facts.distribution_major_version is version('9', '<=') else '' }}/ /


### PR DESCRIPTION
I added variables specific for Debian 10 as opensuse.org changed their naming structure.  This provides support for Debian 10 (Buster)